### PR TITLE
Feat/#28/그룹 내부 및 거래내역

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
 import './App.css'
 import { Outlet } from 'react-router-dom'
+import { TypeProvider } from './contexts/TypeContext.jsx'
 
 function App() {
   return (
-    <>
+    <TypeProvider>
       <Outlet />
-    </>
+    </TypeProvider>
   )
 }
 

--- a/src/components/group/GroupInfoCard.jsx
+++ b/src/components/group/GroupInfoCard.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import styled from 'styled-components'
+
+function GroupInfoCard({
+  money = '1,000,000원',
+  code = '3A4rs3',
+  leftDuration = '3일 12시간 14분 12초',
+  member = '4명 / 4명',
+}) {
+  return (
+    <CardGrid>
+      <Text>시드머니: {`${money}`}</Text>
+      <RightText>입장 코드: {`${code}`}</RightText>
+      <Text>남은 기간: {`${leftDuration}`}</Text>
+      <RightText>참가 인원: {`${member}`}</RightText>
+    </CardGrid>
+  )
+}
+
+export default GroupInfoCard
+
+const CardGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  row-gap: 8px;
+  padding: 16px;
+  background: var(--Neutral-0, #fff);
+`
+
+const Text = styled.p`
+  color: var(--Neutral-900, #333);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px; /* 133.333% */
+`
+
+const RightText = styled.p`
+  color: var(--Neutral-900, #333);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px; /* 133.333% */
+  padding-left: 32px;
+`

--- a/src/components/group/GroupListNow.jsx
+++ b/src/components/group/GroupListNow.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { useNavigate } from 'react-router-dom'
 import List from './List'
 
 const GroupListNow = () => {
+  const navigate = useNavigate()
   const handleItemClick = () => {
     // 해당 그룹 페이지로 이동
-    console.log('페이지 이동')
+    navigate('/group/home')
   }
   return (
     <>

--- a/src/components/group/GroupMenu.jsx
+++ b/src/components/group/GroupMenu.jsx
@@ -15,7 +15,11 @@ const GroupMenuButtons = () => {
         </Row>
         <Row>
           <GroupMiniButton img={pinkSquare} label={'대기주문'} onClick={() => navigate('/')} />
-          <GroupMiniButton img={pinkSquare} label={'거래내역'} onClick={() => navigate('/')} />
+          <GroupMiniButton
+            img={pinkSquare}
+            label={'거래내역'}
+            onClick={() => navigate('/group/transaction')}
+          />
         </Row>
       </ButtonContainer>
       <Label>투자 순위</Label>

--- a/src/components/group/GroupMenu.jsx
+++ b/src/components/group/GroupMenu.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import styled from 'styled-components'
+import pinkSquare from '@/assets/images/img-pink-square.svg'
+import GroupMiniButton from './GroupMiniButton'
+
+const GroupMenuButtons = () => {
+  const navigate = useNavigate()
+  return (
+    <Container>
+      <ButtonContainer>
+        <Row>
+          <GroupMiniButton img={pinkSquare} label={'보유 종목'} onClick={() => navigate('/')} />
+          <GroupMiniButton img={pinkSquare} label={'투자하기'} onClick={() => navigate('/')} />
+        </Row>
+        <Row>
+          <GroupMiniButton img={pinkSquare} label={'대기주문'} onClick={() => navigate('/')} />
+          <GroupMiniButton img={pinkSquare} label={'거래내역'} onClick={() => navigate('/')} />
+        </Row>
+      </ButtonContainer>
+      <Label>투자 순위</Label>
+    </Container>
+  )
+}
+
+export default GroupMenuButtons
+
+const Container = styled.div`
+  padding: 0 16px 16px 16px;
+`
+
+const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px 0;
+`
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`
+const Label = styled.p`
+  color: var(--Neutral-900, #333);
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 28px;
+`

--- a/src/components/group/GroupRankList.jsx
+++ b/src/components/group/GroupRankList.jsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import styled from 'styled-components'
+
+// 더미 랭킹 데이터
+import { dummyRankingData } from '@/pages/group/dummyRankingData'
+
+function GroupRankList(props) {
+  return (
+    <List>
+      {
+        /* 인원 수만큼 mapping */
+        dummyRankingData.map((item) => (
+          <Item key={item.rank}>
+            <Left>
+              <Rank>{item.rank}위</Rank>
+              <Name>{item.name}</Name>
+            </Left>
+            <Profit $isPositive={item.profit > 0}>
+              {item.profit > 0 ? '+' : ''}
+              {item.profit.toLocaleString()}원
+            </Profit>
+          </Item>
+        ))
+      }
+    </List>
+  )
+}
+
+export default GroupRankList
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: var(--Neutral-0, #fff);
+  padding: 0 16px;
+`
+
+const Item = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 0;
+  border-bottom: 0.8px solid #d1d1d1;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`
+
+const Left = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 24px;
+`
+const Rank = styled.p`
+  color: var(--Neutral-600, #5d5d5d);
+  /* Body-Medium */
+  font-family: Inter;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 24px;
+`
+
+const Name = styled.p`
+  color: var(--Neutral-900, #333);
+  /* Head-Medium */
+  font-family: Inter;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 28px;
+`
+
+const Profit = styled.p`
+  color: ${({ $isPositive }) => ($isPositive ? '#FF2E4E' : ' #0084FE')};
+  font-weight: 600;
+  text-align: right;
+  min-width: 80px;
+`

--- a/src/contexts/TypeContext.jsx
+++ b/src/contexts/TypeContext.jsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const TypeContext = createContext('personal') // 타입 personal로 초기화
+
+export const TypeProvider = ({ children }) => {
+  const location = useLocation()
+  const isGroup = location.pathname.startsWith('/group') // url 경로로 타입 판단
+  const type = isGroup ? 'group' : 'personal'
+
+  return <TypeContext.Provider value={type}>{children}</TypeContext.Provider>
+}
+
+export const useType = () => {
+  return useContext(TypeContext)
+}
+
+export default TypeProvider

--- a/src/pages/group/GroupHomePage.jsx
+++ b/src/pages/group/GroupHomePage.jsx
@@ -24,6 +24,7 @@ const GroupHomePage = () => {
           {/* 랭킹 확인 */}
           <GroupRankList />
         </Container>
+        <Space></Space>
       </Scrollable>
       <MenuBar />
     </>
@@ -38,7 +39,7 @@ const Container = styled.div`
   flex: 1;
   background: var(--Neutral-50, #f6f6f6);
 `
-
 const Space = styled.div`
   height: 24px;
+  background: var(--Neutral-50, #f6f6f6);
 `

--- a/src/pages/group/GroupHomePage.jsx
+++ b/src/pages/group/GroupHomePage.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Scrollable } from '@/styles/Scrollable.styled'
 import Header from '@/components/common/Header'
 import MyAssets from '@/components/home/MyAssets'
-import AssetDonut from '@/components/home/AssetDonut'
 import GroupInfoCard from '@/components/group/GroupInfoCard'
 import GroupMenu from '@/components/group/GroupMenu'
 import GroupRankList from '@/components/group/GroupRankList'
@@ -17,7 +16,9 @@ const GroupHomePage = () => {
         {/* 그룹 정보 */}
         <Container>
           <GroupInfoCard />
+          <Space></Space>
           {/* 그룹 내 자산 현황 */}
+          <MyAssets />
           {/* 메뉴 버튼 */}
           <GroupMenu />
           {/* 랭킹 확인 */}
@@ -36,5 +37,8 @@ const Container = styled.div`
   flex-direction: column;
   flex: 1;
   background: var(--Neutral-50, #f6f6f6);
-  padding-bottom: 32px;
+`
+
+const Space = styled.div`
+  height: 24px;
 `

--- a/src/pages/group/GroupHomePage.jsx
+++ b/src/pages/group/GroupHomePage.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Scrollable } from '@/styles/Scrollable.styled'
+import Header from '@/components/common/Header'
+import MyAssets from '@/components/home/MyAssets'
+import AssetDonut from '@/components/home/AssetDonut'
+import GroupInfoCard from '@/components/group/GroupInfoCard'
+import GroupMenu from '@/components/group/GroupMenu'
+import GroupRankList from '@/components/group/GroupRankList'
+import MenuBar from '@/components/common/MenuBar'
+
+const GroupHomePage = () => {
+  return (
+    <>
+      <Scrollable>
+        <Header title='멋쟁이사자처럼 투자 소모임' showIcon={true} path='/group/list' />
+        {/* 그룹 정보 */}
+        <Container>
+          <GroupInfoCard />
+          {/* 그룹 내 자산 현황 */}
+          {/* 메뉴 버튼 */}
+          <GroupMenu />
+          {/* 랭킹 확인 */}
+          <GroupRankList />
+        </Container>
+      </Scrollable>
+      <MenuBar />
+    </>
+  )
+}
+
+export default GroupHomePage
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  background: var(--Neutral-50, #f6f6f6);
+  padding-bottom: 32px;
+`

--- a/src/pages/group/GroupTransactionPage.jsx
+++ b/src/pages/group/GroupTransactionPage.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react'
+import { Scrollable } from '@/styles/Scrollable.styled'
+import styled from 'styled-components'
+import Header from '@/components/common/Header'
+import DayPicker from '@/components/hometransaction/DayPicker'
+import InvestSummaryCard from '@/components/hometransaction/InvestSummaryCard'
+import TransactionList from '@/components/hometransaction/TransactionList'
+
+import { dummyData } from '@/components/hometransaction/dummyData' //더미데이터
+import MenuBar from '@/components/common/MenuBar'
+
+const formatting = (n) => String(n).padStart(2, '0')
+const getTodayDate = () => {
+  const d = new Date()
+  return `${d.getFullYear()}-${formatting(d.getMonth() + 1)}-${formatting(d.getDate())}`
+}
+
+const GroupTransactionPage = () => {
+  const [range, setRange] = useState({
+    start: '2025-01-01',
+    end: getTodayDate(),
+  })
+
+  const [summary, setSummary] = useState({})
+  const [transactions, setTransactions] = useState([])
+
+  useEffect(() => {
+    const found = dummyData.find(
+      (d) => new Date(d.start) <= new Date(range.end) && new Date(d.end) >= new Date(range.start),
+    )
+
+    if (found) {
+      setSummary(found.summary)
+      setTransactions(found.transactions)
+    } else {
+      setSummary({ profit: 0, profitRate: 0, totalBuy: 0, totalSell: 0 })
+      setTransactions([])
+    }
+  }, [range])
+
+  return (
+    <>
+      <Scrollable>
+        <Header title='거래내역' showIcon='true' path='/group/home' />
+        <TopContainer>
+          <DayPicker value={range} onApply={setRange} />
+          <InvestSummaryCard summary={summary} />
+        </TopContainer>
+        <BottomContainer>
+          <TransactionList transactions={transactions} />
+        </BottomContainer>
+      </Scrollable>
+      <MenuBar />
+    </>
+  )
+}
+
+export default GroupTransactionPage
+
+const TopContainer = styled.div`
+  padding: 32px 16px 0 16px;
+`
+
+const BottomContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 16px 16px 32px 16px;
+  background: var(--Neutral-50, #f6f6f6);
+  flex: 1;
+`

--- a/src/pages/group/dummyRankingData.js
+++ b/src/pages/group/dummyRankingData.js
@@ -1,0 +1,6 @@
+export const dummyRankingData = [
+  { rank: 1, name: '기디성준', profit: 33367 },
+  { rank: 2, name: '기디운영진', profit: 13367 },
+  { rank: 3, name: '내가투자왕', profit: -13367 },
+  { rank: 4, name: '존버', profit: -33367 },
+]

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -20,6 +20,7 @@ import SavedChattingPage from './pages/my/SavedChattingPage'
 import MoneyChargePage from './pages/my/MoneyChargePage'
 import EditInfoPage from './pages/my/EditInfoPage'
 import GroupHomePage from './pages/group/GroupHomePage'
+import GroupTransactionPage from './pages/group/GroupTransactionPage'
 
 const router = createBrowserRouter([
   {
@@ -62,6 +63,10 @@ const router = createBrowserRouter([
       {
         path: 'home',
         element: <GroupHomePage />,
+      },
+      {
+        path: 'transaction',
+        element: <GroupTransactionPage />,
       },
     ],
   },

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -18,6 +18,7 @@ import MyPage from './pages/my/MyPage'
 import SavedChattingPage from './pages/my/SavedChattingPage'
 import MoneyChargePage from './pages/my/MoneyChargePage'
 import EditInfoPage from './pages/my/EditInfoPage'
+import GroupHomePage from './pages/group/GroupHomePage'
 
 const router = createBrowserRouter([
   {
@@ -55,6 +56,10 @@ const router = createBrowserRouter([
       {
         path: 'create',
         element: <GroupCreatePage />,
+      },
+      {
+        path: 'home',
+        element: <GroupHomePage />,
       },
     ],
   },


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
closed #28 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
- 그룹 내부 (4.5) / 그룹 거래 내역 (4.6)
  - 그룹 홈 페이지 제작
  - 그룹 거래 내역 페이지 제작 
 

- Context Api 설정
  - TypeContext 파일(/src/contexts/TypeContext.jsx)에서 현재 페이지가 개인 페이지(personal)인지 그룹 페이지(group)인지 구분
  - type의 기본값은 personal로 설정
  - useLocation()으로 현재 url 경로 가져오고, url 경로가 /group으로 시작하면 type을 group으로 바꿔줌
  - `const type = useType()`으로 group 또는 personal 값 반환 받아 연동할 때 각기 다른 api 경로로 요청보냄

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->

